### PR TITLE
Revert "Remove the py-pynsq until we can fix it to compile for py3"

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -416,6 +416,9 @@ ports += "www/novnc-websockify"
 ports += "net/libvncserver"
 ports += "devel/libhyve-remote"
 
+ports += "net/nsq"
+ports += "net/py-pynsq"
+
 if DEBUG:
 	ports += "misc/py-pexpect"
 	ports += {

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -416,6 +416,9 @@ ports += "www/novnc-websockify"
 ports += "net/libvncserver"
 ports += "devel/libhyve-remote"
 
+ports += "net/nsq"
+ports += "net/py-pynsq"
+
 if DEBUG:
 	ports += "misc/py-pexpect"
 	ports += {


### PR DESCRIPTION
This reverts commit dbe4f23f2b30338f5b944cf38a562729fac167e3.

DEPENDS: https://github.com/freenas/ports/tree/kris-pynsq-fix