### PR TITLE
Switch to " git log -1 --pretty=format:%ct" when figuring out

### DIFF
--- a/build/config/ports-installer.pyd
+++ b/build/config/ports-installer.pyd
@@ -23,7 +23,7 @@
 # SUCH DAMAGE.
 #
 
-freenas_git_rev = sh("git -C ${BE_ROOT}/freenas rev-list HEAD --count") \
+freenas_git_rev = sh("git -C ${BE_ROOT}/freenas log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/freenas") \
     else "0"
 

--- a/build/profiles/fn_head/ports-freenas.pyd
+++ b/build/profiles/fn_head/ports-freenas.pyd
@@ -24,15 +24,15 @@
 #
 
 
-freenas_git_rev = sh("git -C ${BE_ROOT}/freenas rev-list HEAD --count") \
+freenas_git_rev = sh("git -C ${BE_ROOT}/freenas log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/freenas") \
     else "0"
 
-webui_git_rev = sh("git -C ${BE_ROOT}/webui rev-list HEAD --count") \
+webui_git_rev = sh("git -C ${BE_ROOT}/webui log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/webui") \
     else "0"
 
-iocage_git_rev = sh("git -C ${BE_ROOT}/iocage rev-list HEAD --count") \
+iocage_git_rev = sh("git -C ${BE_ROOT}/iocage log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/iocage") \
     else "0"
 
@@ -57,7 +57,7 @@ ports += {
 }
 
 if PRODUCT == "TrueNAS":
-    truenas_git_rev = sh("git -C ${BE_ROOT}/truenas rev-list HEAD --count") \
+    truenas_git_rev = sh("git -C ${BE_ROOT}/truenas log -1 --pretty=format:%ct") \
         if exists("${BE_ROOT}/truenas") \
         else "0"
     ports += {
@@ -163,7 +163,7 @@ dedicated_repo_ports = [
 ]
 
 for iter_port in dedicated_repo_ports:
-    iter_port_git_rev = sh("git -C ${BE_ROOT}/{0} rev-list HEAD --count".format(iter_port)) \
+    iter_port_git_rev = sh("git -C ${BE_ROOT}/{0} log -1 --pretty=format:%ct".format(iter_port)) \
         if exists("${BE_ROOT}/{0}".format(iter_port)) \
         else "0"
 

--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -23,7 +23,7 @@
 # SUCH DAMAGE.
 #
 
-samba_git_rev = sh("git -C ${BE_ROOT}/samba rev-list HEAD --count") if exists("${BE_ROOT}/samba") else "0"
+samba_git_rev = sh("git -C ${BE_ROOT}/samba log -1 --pretty=format:%ct") if exists("${BE_ROOT}/samba") else "0"
 
 ports += {
     "name": "ports-mgmt/pkg",

--- a/build/profiles/freenas/ports-freenas.pyd
+++ b/build/profiles/freenas/ports-freenas.pyd
@@ -24,15 +24,15 @@
 #
 
 
-freenas_git_rev = sh("git -C ${BE_ROOT}/freenas rev-list HEAD --count") \
+freenas_git_rev = sh("git -C ${BE_ROOT}/freenas log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/freenas") \
     else "0"
 
-webui_git_rev = sh("git -C ${BE_ROOT}/webui rev-list HEAD --count") \
+webui_git_rev = sh("git -C ${BE_ROOT}/webui log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/webui") \
     else "0"
 
-iocage_git_rev = sh("git -C ${BE_ROOT}/iocage rev-list HEAD --count") \
+iocage_git_rev = sh("git -C ${BE_ROOT}/iocage log -1 --pretty=format:%ct") \
     if exists("${BE_ROOT}/iocage") \
     else "0"
 
@@ -57,7 +57,7 @@ ports += {
 }
 
 if PRODUCT == "TrueNAS":
-    truenas_git_rev = sh("git -C ${BE_ROOT}/truenas rev-list HEAD --count") \
+    truenas_git_rev = sh("git -C ${BE_ROOT}/truenas log -1 --pretty=format:%ct") \
         if exists("${BE_ROOT}/truenas") \
         else "0"
     ports += {
@@ -163,7 +163,7 @@ dedicated_repo_ports = [
 ]
 
 for iter_port in dedicated_repo_ports:
-    iter_port_git_rev = sh("git -C ${BE_ROOT}/{0} rev-list HEAD --count".format(iter_port)) \
+    iter_port_git_rev = sh("git -C ${BE_ROOT}/{0} log -1 --pretty=format:%ct".format(iter_port)) \
         if exists("${BE_ROOT}/{0}".format(iter_port)) \
         else "0"
 

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -23,7 +23,7 @@
 # SUCH DAMAGE.
 #
 
-samba_git_rev = sh("git -C ${BE_ROOT}/samba rev-list HEAD --count") if exists("${BE_ROOT}/samba") else "0"
+samba_git_rev = sh("git -C ${BE_ROOT}/samba log -1 --pretty=format:%ct") if exists("${BE_ROOT}/samba") else "0"
 
 ports += {
     "name": "ports-mgmt/pkg",


### PR DESCRIPTION
what version to set in the FreeBSD ports we build. This is
to work around an issue with shallow checkouts (Which we should be
using everywhere) and still provide the port a numerical that
increases.