### PR TITLE
Revert "Light up as many consoles as we can."

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -9,12 +9,6 @@ loader_brand="%NANO_LABEL_LOWER%-brand"
 
 vfs.root.mountfrom="cd9660:iso9660/${CDROM_LABEL}"
 
-# Light up every console we can find.
-boot_multicons="YES"
-console="comconsole,efi,vidconsole"
-comconsole_port="0x3f8"
-comconsole_speed="115200"
-
 # The following delay during mounting of root file
 # system is needed because mounting of an IPMI CD-ROM
 # sometimes slow.


### PR DESCRIPTION
This change cause more harm then good.  Without setting boot_serial it
makes unpredictable which console become primary, and on which installer
menu will appear.  We probably need some loader menu or other solution.

Ticket:	#33186
Ticket: #35500

This reverts commit 3b05806bac773630f9f0a322263d8e3ab3c130a0.

(cherry picked from commit 2076c146a7cb15932686080b68df96349ae23d8a)