### PR TITLE
Kernel config changes

### DIFF
--- a/build/profiles/fn_head/config.pyd
+++ b/build/profiles/fn_head/config.pyd
@@ -76,16 +76,9 @@ kernel_modules = [
     "hwpmc",
     "ipoib",
     "mlx4ib",
+    "ocs_fc",
+    "smartpqi",
 ]
-
-if PRODUCT == "TrueNAS":
-    kernel_modules += [
-    ]
-else:
-    kernel_modules += [
-        "netgraph/ether",
-        "netgraph/socket"
-    ]
 
 # World configuration
 make_conf_build = {

--- a/build/profiles/fn_head/config.pyd
+++ b/build/profiles/fn_head/config.pyd
@@ -47,6 +47,7 @@ kernel_modules = [
     "geom",
     "i2c",
     "ipmi",
+    "ipsec",
     "khelp/h_ertt",
     "libiconv",
     "libmchain",

--- a/build/profiles/fn_head/config.pyd
+++ b/build/profiles/fn_head/config.pyd
@@ -80,11 +80,9 @@ kernel_modules = [
 
 if PRODUCT == "TrueNAS":
     kernel_modules += [
-        "syscons/blank",
     ]
 else:
     kernel_modules += [
-        "syscons",
         "netgraph/ether",
         "netgraph/socket"
     ]
@@ -120,6 +118,7 @@ make_conf_build = {
     "WITHOUT_RCMDS":                "yes",
     "WITHOUT_SENDMAIL":             "yes",
     "WITHOUT_SVNLITE":              "yes",
+    "WITHOUT_SYSCONS":              "yes",
     "WITHOUT_SYSINSTALL":           "yes",
     "WITHOUT_TESTS":                "yes",
     "WITHOUT_WIRELESS":             "yes",
@@ -162,7 +161,6 @@ make_conf_boot = {
     "WITHOUT_NIS":                  "yes",
     "WITHOUT_NLS":                  "yes",
     "WITHOUT_PMC":                  "yes",
-    "WITHOUT_SYSCONS":              "yes",
     "WITHOUT_VT":                   "yes",
 }
 

--- a/build/profiles/fn_head/kernel/FREENAS.amd64
+++ b/build/profiles/fn_head/kernel/FREENAS.amd64
@@ -110,7 +110,6 @@ device		siis			# SiliconImage SiI3124/SiI3132/SiI3531 SATA
 # SCSI Controllers
 device		ahc			# AHA2940 and onboard AIC7xxx devices
 device		ahd			# AHA39320/29320 and onboard AIC79xx devices
-#device		esp			# AMD 53C974 (Tekram DC-390(T))
 device		hptiop			# Highpoint RocketRaid 3xxx series
 device		isp			# Qlogic family
 #device		ispfw			# Firmware for QLogic HBAs- normally a module
@@ -119,14 +118,9 @@ device		mps			# LSI-Logic MPT-Fusion 2
 device		mpr			# LSI-Logic MPT-Fusion 3
 #device		ncr			# NCR/Symbios Logic
 device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
-#device		trm			# Tekram DC395U/UW/F DC315U adapters
 
-#device		adv			# Advansys SCSI adapters
-#device		adw				# Advansys wide SCSI adapters
-#adevice	aic			# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
-#device		bt			# Buslogic/Mylex MultiMaster SCSI adapters
 device		isci			# Intel C600 SAS controller
-device		ocs_fc			# Emulex FC adapters
+#device		ocs_fc			# Emulex FC adapters
 
 # ATA/SCSI peripherals
 device		scbus			# SCSI bus (required for ATA/SCSI)
@@ -142,31 +136,29 @@ device		ctl			# CAM Target Layer
 device		amr			# AMI MegaRAID
 device		arcmsr			# Areca SATA II RAID
 device		ciss			# Compaq Smart RAID 5*
-device		dpt			# DPT Smartcache III, IV - See NOTES for options
 device		hptmv			# Highpoint RocketRAID 182x
 device		hptnr			# Highpoint DC7280, R750
 device		hptrr			# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
 device		hpt27xx			# Highpoint RocketRAID 27xx
 device		iir			# Intel Integrated RAID
 device		ips			# IBM (Adaptec) ServeRAID
-device		mly			# Mylex AcceleRAID/eXtremeRAID
+#device		mly			# Mylex AcceleRAID/eXtremeRAID
 device		twa			# 3ware 9000 series PATA/SATA RAID
-device		smartpqi		# Microsemi smartpqi driver
+#device		smartpqi		# Microsemi smartpqi driver
 device		tws			# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
 
 # RAID controllers
 device		aac			# Adaptec FSA RAID
 device		aacp			# SCSI passthrough for aac (requires CAM)
 device		aacraid			# Adaptec by PMC RAID
-#device		ida			# Compaq Smart RAID
 device		mfi			# LSI MegaRAID SAS
 device		mfip			# LSI MegaRAID SAS passthrough, requires CAM
-device		mlx			# Mylex DAC960 family
+#device		mlx			# Mylex DAC960 family
 device		mrsas			# LSI/Avago MegaRAID SAS/SATA, 6Gb/s and 12Gb/s
 device		pmspcv			# PMC-Sierra SAS/SATA Controller driver
 #XXX pointer/int warnings
 #device		pst			# Promise Supertrak SX6000
-device		twe			# 3ware ATA RAID
+#device		twe			# 3ware ATA RAID
 
 # NVM Express (NVMe) support
 device		nvme			# base NVMe driver
@@ -324,7 +316,6 @@ options		IPOIB_CM	# IPoIB connected mode
 ## FreeNAS specific modifications
 # misc
 device		padlock
-options		NETGRAPH
 device		snp
 device		epair		# A pair of virtual back-to-back connected Ethernet interfaces
 device		if_bridge	# network bridge device

--- a/build/profiles/fn_head/kernel/FREENAS.amd64
+++ b/build/profiles/fn_head/kernel/FREENAS.amd64
@@ -29,6 +29,7 @@ options 	PREEMPTION		# Enable kernel thread preemption
 options 	VIMAGE			# Subsystem virtualization, e.g. VNET
 options 	INET			# InterNETworking
 options 	INET6			# IPv6 communications protocols
+options 	IPSEC_SUPPORT		# Allow kldload of ipsec and tcpmd5
 options 	TCP_OFFLOAD		# TCP offload
 #options 	SCTP			# Stream Control Transmission Protocol
 options 	FFS			# Berkeley Fast Filesystem

--- a/build/profiles/fn_head/kernel/FREENAS.amd64
+++ b/build/profiles/fn_head/kernel/FREENAS.amd64
@@ -4,11 +4,11 @@
 # For more information on this file, please read the config(5) manual page,
 # and/or the handbook section on Kernel Configuration Files:
 #
-#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
+#    https://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
 #
 # The handbook is also available locally in /usr/share/doc/handbook
 # if you've installed the doc distribution, otherwise always see the
-# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
+# FreeBSD World Wide Web server (https://www.FreeBSD.org/) for the
 # latest information.
 #
 # An exhaustive list of options and more detailed explanations of the
@@ -26,6 +26,7 @@ makeoptions	WITH_CTF=1		# Run ctfconvert(1) for DTrace support
 
 options 	SCHED_ULE		# ULE scheduler
 options 	PREEMPTION		# Enable kernel thread preemption
+options 	VIMAGE			# Subsystem virtualization, e.g. VNET
 options 	INET			# InterNETworking
 options 	INET6			# IPv6 communications protocols
 options 	TCP_OFFLOAD		# TCP offload
@@ -55,6 +56,7 @@ options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
 options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
 options 	COMPAT_FREEBSD9		# Compatible with FreeBSD9
 options 	COMPAT_FREEBSD10	# Compatible with FreeBSD10
+options 	COMPAT_FREEBSD11	# Compatible with FreeBSD11
 options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
 options 	KTRACE			# ktrace(1) support
 options 	STACK			# stack(9) support
@@ -106,11 +108,7 @@ device		siis			# SiliconImage SiI3124/SiI3132/SiI3531 SATA
 
 # SCSI Controllers
 device		ahc			# AHA2940 and onboard AIC7xxx devices
-options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
-					# output.  Adds ~128k to driver.
 device		ahd			# AHA39320/29320 and onboard AIC79xx devices
-options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
-					# output.  Adds ~215k to driver.
 #device		esp			# AMD 53C974 (Tekram DC-390(T))
 device		hptiop			# Highpoint RocketRaid 3xxx series
 device		isp			# Qlogic family
@@ -127,6 +125,7 @@ device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
 #adevice	aic			# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
 #device		bt			# Buslogic/Mylex MultiMaster SCSI adapters
 device		isci			# Intel C600 SAS controller
+device		ocs_fc			# Emulex FC adapters
 
 # ATA/SCSI peripherals
 device		scbus			# SCSI bus (required for ATA/SCSI)
@@ -151,6 +150,7 @@ device		iir			# Intel Integrated RAID
 device		ips			# IBM (Adaptec) ServeRAID
 device		mly			# Mylex AcceleRAID/eXtremeRAID
 device		twa			# 3ware 9000 series PATA/SATA RAID
+device		smartpqi		# Microsemi smartpqi driver
 device		tws			# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
 
 # RAID controllers
@@ -207,7 +207,8 @@ device		em			# Intel PRO/1000 Gigabit Ethernet Family
 device		ix			# Intel PRO/10GbE PCIE PF Ethernet
 device		ixv			# Intel PRO/10GbE PCIE VF Ethernet
 device		ixl			# Intel XL710 40Gbe PCIE Ethernet
-device		ixlv			# Intel XL710 40Gbe VF PCIE Ethernet
+#options		IXL_IW			# Enable iWARP Client Interface in ixl(4)
+#device		ixlv			# Intel XL710 40Gbe VF PCIE Ethernet
 device		le			# AMD Am7900 LANCE and Am79C9xx PCnet
 device		mlx4			# Mellanox ConnectX common code
 device		mlx4en			# Mellanox ConnectX HCA Ethernet
@@ -331,7 +332,6 @@ options		IPOIB_CM	# IPoIB connected mode
 ## FreeNAS specific modifications
 # misc
 device		padlock
-options		VIMAGE
 options		NETGRAPH
 device		snp
 device		epair		# A pair of virtual back-to-back connected Ethernet interfaces

--- a/build/profiles/fn_head/kernel/FREENAS.amd64
+++ b/build/profiles/fn_head/kernel/FREENAS.amd64
@@ -179,15 +179,6 @@ device		psm			# PS/2 mouse
 
 device		kbdmux			# keyboard multiplexer
 
-device		vga			# VGA video card driver
-options 	VESA			# Add support for VESA BIOS Extensions (VBE)
-
-device		splash			# Splash screen and screen saver support
-
-# syscons is the default console driver, resembling an SCO console
-device		sc
-options 	SC_PIXEL_MODE		# add support for the raster text mode
-
 # vt is the new video console driver
 device		vt
 device		vt_vga

--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -81,11 +81,9 @@ kernel_modules = [
 
 if PRODUCT == "TrueNAS":
     kernel_modules += [
-        "syscons/blank",
     ]
 else:
     kernel_modules += [
-        "syscons",
         "netgraph/ether",
         "netgraph/socket"
     ]
@@ -121,6 +119,7 @@ make_conf_build = {
     "WITHOUT_RCMDS":                "yes",
     "WITHOUT_SENDMAIL":             "yes",
     "WITHOUT_SVNLITE":              "yes",
+    "WITHOUT_SYSCONS":              "yes",
     "WITHOUT_SYSINSTALL":           "yes",
     "WITHOUT_TESTS":                "yes",
     "WITHOUT_WIRELESS":             "yes",
@@ -163,7 +162,6 @@ make_conf_boot = {
     "WITHOUT_NIS":                  "yes",
     "WITHOUT_NLS":                  "yes",
     "WITHOUT_PMC":                  "yes",
-    "WITHOUT_SYSCONS":              "yes",
     "WITHOUT_VT":                   "yes",
 }
 

--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -77,16 +77,9 @@ kernel_modules = [
     "ipoib",
     "mlx4ib",
     "mthca",
+    "ocs_fc",
+    "smartpqi",
 ]
-
-if PRODUCT == "TrueNAS":
-    kernel_modules += [
-    ]
-else:
-    kernel_modules += [
-        "netgraph/ether",
-        "netgraph/socket"
-    ]
 
 # World configuration
 make_conf_build = {

--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -47,6 +47,7 @@ kernel_modules = [
     "geom",
     "i2c",
     "ipmi",
+    "ipsec",
     "khelp/h_ertt",
     "libiconv",
     "libmchain",

--- a/build/profiles/freenas/kernel/FREENAS.amd64
+++ b/build/profiles/freenas/kernel/FREENAS.amd64
@@ -108,12 +108,7 @@ device		siis			# SiliconImage SiI3124/SiI3132/SiI3531 SATA
 
 # SCSI Controllers
 device		ahc			# AHA2940 and onboard AIC7xxx devices
-options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
-					# output.  Adds ~128k to driver.
 device		ahd			# AHA39320/29320 and onboard AIC79xx devices
-options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
-					# output.  Adds ~215k to driver.
-#device		esp			# AMD 53C974 (Tekram DC-390(T))
 device		hptiop			# Highpoint RocketRaid 3xxx series
 device		isp			# Qlogic family
 #device		ispfw			# Firmware for QLogic HBAs- normally a module
@@ -122,14 +117,9 @@ device		mps			# LSI-Logic MPT-Fusion 2
 device		mpr			# LSI-Logic MPT-Fusion 3
 #device		ncr			# NCR/Symbios Logic
 device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
-#device		trm			# Tekram DC395U/UW/F DC315U adapters
 
-#device		adv			# Advansys SCSI adapters
-#device		adw				# Advansys wide SCSI adapters
-#adevice	aic			# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
-#device		bt			# Buslogic/Mylex MultiMaster SCSI adapters
 device		isci			# Intel C600 SAS controller
-device		ocs_fc			# Emulex FC adapters
+#device		ocs_fc			# Emulex FC adapters
 
 # ATA/SCSI peripherals
 device		scbus			# SCSI bus (required for ATA/SCSI)
@@ -145,31 +135,29 @@ device		ctl			# CAM Target Layer
 device		amr			# AMI MegaRAID
 device		arcmsr			# Areca SATA II RAID
 device		ciss			# Compaq Smart RAID 5*
-device		dpt			# DPT Smartcache III, IV - See NOTES for options
 device		hptmv			# Highpoint RocketRAID 182x
 device		hptnr			# Highpoint DC7280, R750
 device		hptrr			# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
 device		hpt27xx			# Highpoint RocketRAID 27xx
 device		iir			# Intel Integrated RAID
 device		ips			# IBM (Adaptec) ServeRAID
-device		mly			# Mylex AcceleRAID/eXtremeRAID
+#device		mly			# Mylex AcceleRAID/eXtremeRAID
 device		twa			# 3ware 9000 series PATA/SATA RAID
-device		smartpqi		# Microsemi smartpqi driver
+#device		smartpqi		# Microsemi smartpqi driver
 device		tws			# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
 
 # RAID controllers
 device		aac			# Adaptec FSA RAID
 device		aacp			# SCSI passthrough for aac (requires CAM)
 device		aacraid			# Adaptec by PMC RAID
-#device		ida			# Compaq Smart RAID
 device		mfi			# LSI MegaRAID SAS
 device		mfip			# LSI MegaRAID SAS passthrough, requires CAM
-device		mlx			# Mylex DAC960 family
+#device		mlx			# Mylex DAC960 family
 device		mrsas			# LSI/Avago MegaRAID SAS/SATA, 6Gb/s and 12Gb/s
 device		pmspcv			# PMC-Sierra SAS/SATA Controller driver
 #XXX pointer/int warnings
 #device		pst			# Promise Supertrak SX6000
-device		twe			# 3ware ATA RAID
+#device		twe			# 3ware ATA RAID
 
 # NVM Express (NVMe) support
 device		nvme			# base NVMe driver
@@ -328,7 +316,6 @@ options		IPOIB_CM	# IPoIB connected mode
 # misc
 device		padlock
 options		VIMAGE
-options		NETGRAPH
 device		snp
 device		epair		# A pair of virtual back-to-back connected Ethernet interfaces
 device		if_bridge	# network bridge device

--- a/build/profiles/freenas/kernel/FREENAS.amd64
+++ b/build/profiles/freenas/kernel/FREENAS.amd64
@@ -128,6 +128,7 @@ device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
 #adevice	aic			# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
 #device		bt			# Buslogic/Mylex MultiMaster SCSI adapters
 device		isci			# Intel C600 SAS controller
+device		ocs_fc			# Emulex FC adapters
 
 # ATA/SCSI peripherals
 device		scbus			# SCSI bus (required for ATA/SCSI)
@@ -152,6 +153,7 @@ device		iir			# Intel Integrated RAID
 device		ips			# IBM (Adaptec) ServeRAID
 device		mly			# Mylex AcceleRAID/eXtremeRAID
 device		twa			# 3ware 9000 series PATA/SATA RAID
+device		smartpqi		# Microsemi smartpqi driver
 device		tws			# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
 
 # RAID controllers

--- a/build/profiles/freenas/kernel/FREENAS.amd64
+++ b/build/profiles/freenas/kernel/FREENAS.amd64
@@ -28,6 +28,7 @@ options 	SCHED_ULE		# ULE scheduler
 options 	PREEMPTION		# Enable kernel thread preemption
 options 	INET			# InterNETworking
 options 	INET6			# IPv6 communications protocols
+options 	IPSEC_SUPPORT		# Allow kldload of ipsec and tcpmd5
 options 	TCP_OFFLOAD		# TCP offload
 #options 	SCTP			# Stream Control Transmission Protocol
 options 	FFS			# Berkeley Fast Filesystem

--- a/build/profiles/freenas/kernel/FREENAS.amd64
+++ b/build/profiles/freenas/kernel/FREENAS.amd64
@@ -182,15 +182,6 @@ device		psm			# PS/2 mouse
 
 device		kbdmux			# keyboard multiplexer
 
-device		vga			# VGA video card driver
-options 	VESA			# Add support for VESA BIOS Extensions (VBE)
-
-device		splash			# Splash screen and screen saver support
-
-# syscons is the default console driver, resembling an SCO console
-device		sc
-options 	SC_PIXEL_MODE		# add support for the raster text mode
-
 # vt is the new video console driver
 device		vt
 device		vt_vga


### PR DESCRIPTION
This is a combination of several changes, aimed to sync kernel configs with upstream from one side, add modules for IPSEC and couple new HBA drivers smartpqi and ocs_fc (unfortunately we can't link them statically), and still try to keep dtrace working by reducing number of types in kernel (by removing syscons, netgraph and few ancient hardware drivers: dpt, mlx, mly, twe).