### PR TITLE
Clarify installer boot loader menu

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -1,6 +1,7 @@
 #
 # Boot loader file for ${PRODUCT}
 #
+product_name="${PRODUCT} Installer"
 autoboot_delay="2"
 loader_logo="%NANO_LABEL_LOWER%"
 loader_menu_title="${PRODUCT} Installer"

--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -3,7 +3,7 @@
 #
 autoboot_delay="2"
 loader_logo="%NANO_LABEL_LOWER%"
-loader_menu_title=" "
+loader_menu_title="${PRODUCT} Installer"
 loader_version=" "
 loader_brand="%NANO_LABEL_LOWER%-brand"
 


### PR DESCRIPTION
Adds a loader variable to indicate the product name in menu entries and wherever else it may be handy. It helps distinguish the installer media from an installed system.

Sets the loader menu title to show that the ${PRODUCT} installer is being booted, not an existing installation.