### PR TITLE
Increase loader autoboot timeout

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -2,7 +2,7 @@
 # Boot loader file for ${PRODUCT}
 #
 product_name="${PRODUCT} Installer"
-autoboot_delay="2"
+autoboot_delay="10"
 loader_logo="%NANO_LABEL_LOWER%"
 loader_menu_title="${PRODUCT} Installer"
 loader_version=" "


### PR DESCRIPTION
Sets the installer autoboot delay to 10 seconds to give the user enough
time to read the menu options and make a choice.

Ticket: #37970