### PR TITLE
Fix empty product name in loader menu

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -1,7 +1,7 @@
 #
 # Boot loader file for ${PRODUCT}
 #
-product_name="${PRODUCT} Installer"
+product="${PRODUCT} Installer"
 autoboot_delay="10"
 loader_logo="%NANO_LABEL_LOWER%"
 loader_menu_title="${PRODUCT} Installer"


### PR DESCRIPTION
*_name has special meaning in loader.conf so is a bad variable name.
Rename ${product_name} to ${product} so it behaves like a regular
environment variable.

Ticket: #35730