### PR TITLE
Fix loader logo and brand artwork

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -3,10 +3,10 @@
 #
 product="${PRODUCT} Installer"
 autoboot_delay="10"
-loader_logo="%NANO_LABEL_LOWER%"
+loader_logo="${PRODUCT}"
 loader_menu_title="${PRODUCT} Installer"
 loader_version=" "
-loader_brand="%NANO_LABEL_LOWER%-brand"
+loader_brand="${PRODUCT}"
 
 vfs.root.mountfrom="cd9660:iso9660/${CDROM_LABEL}"
 


### PR DESCRIPTION
Use the new template system variable instead of the obsolete nanobsd placeholder.
The artwork has been moved to files corresponding to ${PRODUCT} in the other repos.

Ticket: #38455