### PR TITLE
Remove memtest86+ from system ports build

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -400,7 +400,6 @@ ports += "misc/mbuffer"
 ports += "devel/git-lite"
 ports += "sysutils/zfs-stats-lite"
 ports += "sysutils/ncdu"
-ports += "sysutils/memtest86+"
 
 # There ports are all vm related.
 ports += "www/novnc"

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -401,7 +401,6 @@ ports += "misc/mbuffer"
 ports += "devel/git-lite"
 ports += "sysutils/zfs-stats-lite"
 ports += "sysutils/ncdu"
-ports += "sysutils/memtest86+"
 
 # There ports are all vm related.
 ports += "www/novnc"


### PR DESCRIPTION
The port doesn't work on the systems FreeNAS targets.

Ticket: #38739