### PR TITLE
tkt-30663: Add graphics/drm-next-kmod to system ports build

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -409,6 +409,8 @@ ports += "devel/libhyve-remote"
 ports += "net/nsq"
 ports += "net/py-pynsq"
 
+ports += "graphics/drm-next-kmod"
+
 if DEBUG:
 	ports += "misc/py-pexpect"
 	ports += {

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -410,6 +410,8 @@ ports += "devel/libhyve-remote"
 ports += "net/nsq"
 ports += "net/py-pynsq"
 
+ports += "graphics/drm-next-kmod"
+
 if DEBUG:
 	ports += "misc/py-pexpect"
 	ports += {


### PR DESCRIPTION
These are not loaded by default, but are included for testing.

Ticket: #30663