### PR TITLE
Wait for all device probe to complete before mounting root

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -10,6 +10,12 @@ loader_brand="${PRODUCT}"
 
 vfs.root.mountfrom="cd9660:iso9660/${CDROM_LABEL}"
 
+# Wait for all device probe to complete before mounting root, even if the
+# root device is already available.  This allows to avoid USB probe messages
+# printed over the installer menu.  This is needed only in installer with
+# its UFS, since ZFS root of installed system implies it automatically.
+vfs.root_mount_always_wait="1"
+
 # The following delay during mounting of root file
 # system is needed because mounting of an IPMI CD-ROM
 # sometimes slow.


### PR DESCRIPTION
Wait for all device probe to complete before mounting root, even if the
root device is already available.  This allows to avoid USB probe messages
printed over the installer menu.  This is needed only in installer with
its UFS, since ZFS root of installed system implies it automatically.

Ticket:	#35497
(cherry picked from commit 63c31d6a7e7126c2ec9a7a2fc7092e0544f77de5)