### PR TITLE
Reduce the number of make jobs to ncpu + 1

### DIFF
--- a/build/config/env.pyd
+++ b/build/config/env.pyd
@@ -136,5 +136,5 @@ DEBUG_ROOT = "${OBJDIR}/debug"
 # Calculate make jobs number, PXZ acceleration and so on
 HW_NCPU = sh("sysctl -n hw.ncpu")
 HW_PHYSMEM = sh("sysctl -n hw.physmem")
-MAKE_JOBS = str(int(HW_NCPU) * 2 + 1)
+MAKE_JOBS = str(int(HW_NCPU) + 1)
 PXZ_ACCEL = "-T${HW_NCPU}"


### PR DESCRIPTION
This avoids oversubscribing system resources, which can cause builds to fail when there is a lot of work to be done.
(see also https://github.com/freenas/build/pull/109 and https://github.com/freenas/build/pull/109#issuecomment-423414198)