### PR TITLE
Add SD/MMC stack into the kernel.

### DIFF
--- a/build/profiles/fn_head/kernel/FREENAS.amd64
+++ b/build/profiles/fn_head/kernel/FREENAS.amd64
@@ -255,6 +255,11 @@ device		usb			# USB Bus (required)
 device		ukbd			# Keyboard
 device		umass			# Disks/Mass storage - Requires scbus and da
 
+# MMC/SD
+device		mmc			# MMC/SD bus
+device		mmcsd			# MMC/SD memory card
+device		sdhci			# Generic PCI SD Host Controller
+
 # VirtIO support
 device		virtio			# Generic VirtIO bus (required)
 device		virtio_pci		# VirtIO PCI device

--- a/build/profiles/freenas/kernel/FREENAS.amd64
+++ b/build/profiles/freenas/kernel/FREENAS.amd64
@@ -254,6 +254,11 @@ device		usb			# USB Bus (required)
 device		ukbd			# Keyboard
 device		umass			# Disks/Mass storage - Requires scbus and da
 
+# MMC/SD
+device		mmc			# MMC/SD bus
+device		mmcsd			# MMC/SD memory card
+device		sdhci			# Generic PCI SD Host Controller
+
 # VirtIO support
 device		virtio			# Generic VirtIO bus (required)
 device		virtio_pci		# VirtIO PCI device


### PR DESCRIPTION
There are some systems using embedded eMMC chip as boot device.
While such devices are rare, it would be cool to support them.
The only price I know is ~120 types out of 32K limit in CTF.

Ticket:	#39123
(cherry picked from commit a36b1a1afb29d28d5cea2f75035e6d5e3976f239)