### PR TITLE
Add GEOM mirror support to kernel configs

### DIFF
--- a/build/profiles/fn_head/kernel/FREENAS.amd64
+++ b/build/profiles/fn_head/kernel/FREENAS.amd64
@@ -289,6 +289,7 @@ device		crypto			# Required by IPSEC
 ## FreeNAS shared modifications
 options		GEOM_UZIP
 options		GEOM_ELI
+options		GEOM_MIRROR
 options 	FDESCFS			# File descriptor filesystem
 options 	NULLFS			# NULL filesystem
 options 	UNIONFS			# Union filesystem

--- a/build/profiles/freenas/kernel/FREENAS.amd64
+++ b/build/profiles/freenas/kernel/FREENAS.amd64
@@ -284,6 +284,7 @@ device		crypto			# Required by IPSEC
 ## FreeNAS shared modifications
 options		GEOM_UZIP
 options		GEOM_ELI
+options		GEOM_MIRROR
 options 	FDESCFS			# File descriptor filesystem
 options 	NULLFS			# NULL filesystem
 options 	UNIONFS			# Union filesystem


### PR DESCRIPTION
This is needed for creating mirrored swap partitions with gmirror.

Ticket: #40392