### PR TITLE
Add x11/nvidia-driver port to the system

### DIFF
--- a/build/profiles/fn_head/config.pyd
+++ b/build/profiles/fn_head/config.pyd
@@ -134,6 +134,7 @@ make_conf_pkg = {
     "BATCH":                        "yes",
     "WRKDIRPREFIX":                 "/wrkdirs",
     "DISABLE_LICENSES":             "yes",
+    "MESA_LLVM_VER":                "",
     "DEBUG_FLAGS":                  "-g",
     "CFLAGS":                       "+= -g",
     "STRIP":                        "",

--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -407,6 +407,10 @@ ports += "net/nsq"
 ports += "net/py-pynsq"
 
 ports += "graphics/drm-next-kmod"
+ports += {
+	"name": "x11/nvidia-driver",
+	"options": ["OPTIONS_FILE_UNSET+=LINUX"]
+}
 
 if DEBUG:
 	ports += "misc/py-pexpect"

--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -411,6 +411,11 @@ ports += {
 	"name": "x11/nvidia-driver",
 	"options": ["OPTIONS_FILE_UNSET+=LINUX"]
 }
+# This is one of nvidia-driver dependencies.  Removal of EGL is needed to remove LLVM.
+ports += {
+	"name": "graphics/libepoxy",
+	"options": ["OPTIONS_FILE_UNSET+=EGL"]
+}
 
 if DEBUG:
 	ports += "misc/py-pexpect"

--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -135,6 +135,7 @@ make_conf_pkg = {
     "BATCH":                        "yes",
     "WRKDIRPREFIX":                 "/wrkdirs",
     "DISABLE_LICENSES":             "yes",
+    "MESA_LLVM_VER":                "",
     "DEBUG_FLAGS":                  "-g",
     "CFLAGS":                       "+= -g",
     "STRIP":                        "",

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -412,6 +412,11 @@ ports += {
 	"name": "x11/nvidia-driver",
 	"options": ["OPTIONS_FILE_UNSET+=LINUX"]
 }
+# This is one of nvidia-driver dependencies.  Removal of EGL is needed to remove LLVM.
+ports += {
+	"name": "graphics/libepoxy",
+	"options": ["OPTIONS_FILE_UNSET+=EGL"]
+}
 
 if DEBUG:
 	ports += "misc/py-pexpect"

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -408,6 +408,10 @@ ports += "net/nsq"
 ports += "net/py-pynsq"
 
 ports += "graphics/drm-next-kmod"
+ports += {
+	"name": "x11/nvidia-driver",
+	"options": ["OPTIONS_FILE_UNSET+=LINUX"]
+}
 
 if DEBUG:
 	ports += "misc/py-pexpect"


### PR DESCRIPTION
This will be used for nvenc and is not loaded by default.

Ticket: #47015