### PR TITLE
11.2 releases must use master for legacy docs

### DIFF
--- a/build/profiles/freenas/repos.pyd
+++ b/build/profiles/freenas/repos.pyd
@@ -58,7 +58,7 @@ repos += {
     "name": "freenas-docs-legacy",
     "path": "freenas-docs-legacy",
     "url": "http://github.com/freenas/freenas-docs.git",
-    "branch": "freenas/11.2-stable"
+    "branch": "master"
 }
 
 


### PR DESCRIPTION
* FreeNAS docs do not share the same branching strategy as every other repo.