### PR TITLE
Use 11.1 branch for py-libzfs

### DIFF
--- a/build/profiles/freenas/repos.pyd
+++ b/build/profiles/freenas/repos.pyd
@@ -79,7 +79,7 @@ repos += {
     "name": "py-libzfs",
     "path": "py-libzfs",
     "url": "https://github.com/freenas/py-libzfs.git",
-    "branch": "master"
+    "branch": "freenas/11.1-stable"
 }
 
 repos += {


### PR DESCRIPTION
* The last change added 6 days ago appears to have broken clean build.
* This was not detected as the portrevision did not change.
* We should not be pulling in new changes this late with an upcoming release.