### PR TITLE
Restore NetGraph build as kernel modules.

### DIFF
--- a/build/profiles/fn_head/config.pyd
+++ b/build/profiles/fn_head/config.pyd
@@ -66,6 +66,9 @@ kernel_modules = [
     "usb",
     "fuse",
     "vmm",
+    "netgraph/netgraph",
+    "netgraph/ether",
+    "netgraph/socket"
     "netmap",
     "nmdm",
     "ntb",

--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -66,6 +66,9 @@ kernel_modules = [
     "usb",
     "fuse",
     "vmm",
+    "netgraph/netgraph",
+    "netgraph/ether",
+    "netgraph/socket"
     "netmap",
     "nmdm",
     "ntb",


### PR DESCRIPTION
Its removal appears to be premature, it is used by VirtualBox plugin.

Ticket:	#50343
Ticket:	#37308