### PR TITLE
Delete vcp directory

### DIFF
--- a/build/profiles/freenas/packages/freenasUI/config
+++ b/build/profiles/freenas/packages/freenasUI/config
@@ -65,6 +65,9 @@ post-upgrade =
              fi
 	     rm -f /tmp/.sqlite3_ha_skip
 
+             # vcp got removed and this is to ensure that the relevant directory is deleted if upgrader fails to remove it
+             rm -rf /usr/local/www/freenasUI/vcp
+
 	     # Remove dangling .pyc files because previously freenas-ui did not include .pyc in pkg-plist
 	     find /usr/local/www/freenasUI -type f -iname "*.pyc" | while read f; do
 	             if ! dirname $f|grep -q __pycache__; then


### PR DESCRIPTION
This commit ensures that vcp directory is deleted at any costs when system is upgraded and for some reason the upgrader might fail to remove the directory.
Ticket: #60138