### PR TITLE
Remove check for WITH_PNFS environment variable

### DIFF
--- a/build/profiles/fn_head/repos.pyd
+++ b/build/profiles/fn_head/repos.pyd
@@ -24,19 +24,11 @@
 #
 from utils import env
 
-if env("WITH_PNFS"):
-    repos += {
-        "name": "os",
-        "path": "os",
-        "url": "https://github.com/freenas/os.git",
-        "branch": "freenas/11-stable-pNFS"
-}
-else:
-    repos += {
-        "name": "os",
-        "path": "os",
-        "url": "https://github.com/freenas/os.git",
-        "branch": "freenas/master"
+repos += {
+    "name": "os",
+    "path": "os",
+    "url": "https://github.com/freenas/os.git",
+    "branch": "freenas/master"
 }
 
 repos += {

--- a/build/profiles/freenas/repos.pyd
+++ b/build/profiles/freenas/repos.pyd
@@ -24,19 +24,11 @@
 #
 from utils import env
 
-if env("WITH_PNFS"):
-    repos += {
-        "name": "os",
-        "path": "os",
-        "url": "https://github.com/freenas/os.git",
-        "branch": "freenas/11-stable-pNFS"
-}
-else:
-    repos += {
-        "name": "os",
-        "path": "os",
-        "url": "https://github.com/freenas/os.git",
-        "branch": "freenas/11-stable"
+repos += {
+    "name": "os",
+    "path": "os",
+    "url": "https://github.com/freenas/os.git",
+    "branch": "freenas/11-stable"
 }
 
 repos += {


### PR DESCRIPTION
As part of ticket 52171, I don't believe checking for WITH_PNFS is useful any longer.

This is mostly to get a jenkins build going.  Any pNFS tests would be good too, obviously.

Ticket: #52171