### PR TITLE
Add sysutils/kiconvtool port to the build for 11.2.

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -43,6 +43,7 @@ ports += {
 }
 ports += "security/stunnel"
 ports += "comms/lrzsz"
+ports += "sysutils/kiconvtool"
 ports += "sysutils/screen"
 ports += "sysutils/iohyve"
 ports += "sysutils/vm-bhyve"

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -43,6 +43,7 @@ ports += {
 }
 ports += "security/stunnel"
 ports += "comms/lrzsz"
+ports += "sysutils/kiconvtool"
 ports += "sysutils/screen"
 ports += "sysutils/iohyve"
 ports += "sysutils/vm-bhyve"


### PR DESCRIPTION
It allows to load iconv tables into kernel for use by jails.

Ticket:	#57543
(cherry picked from commit cafde5dc3f536fe9bce08022b4aabe78e705ff74)