### PR TITLE
Fix stale login.conf

### DIFF
--- a/build/customize/login-conf.py
+++ b/build/customize/login-conf.py
@@ -30,7 +30,7 @@ from utils import chroot
 
 
 def main():
-    chroot('${WORLD_DESTDIR}', 'cap_mkdb /conf/base/etc/login.conf')
+    chroot('${WORLD_DESTDIR}', 'cap_mkdb -f /conf/base/etc/login.conf /conf/base/etc/login.conf.template')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit fixes a bug where we had changed the login.conf file name in freenas repo but hadn't reflected that in freenas/build repo and we were doing cap_mkdb on login.conf not on the renamed file which resulted in different errors because of the stale login.conf.db file.
Ticket: #59211