### PR TITLE
Enable HPN for SSH

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -100,6 +100,7 @@ ports += {
     "name": "security/openssh-portable",
     "options": [
         "OPTIONS_FILE_SET+=HEIMDAL_BASE",
+        "OPTIONS_FILE_SET+=HPN",
         "OPTIONS_FILE_SET+=NONECIPHER",
     ]
 }

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -97,6 +97,7 @@ ports += {
     "name": "security/openssh-portable",
     "options": [
         "OPTIONS_FILE_SET+=HEIMDAL_BASE",
+        "OPTIONS_FILE_SET+=HPN",
         "OPTIONS_FILE_SET+=NONECIPHER",
     ]
 }


### PR DESCRIPTION
It appears the port is broken when built with NONECYPHER, but without HPN.

Ticket: #69805
Ticket: #47092

(cherry picked from commit a1cd2d6cbb48dd60c509779684d264635f752290)