### PR TITLE
Resolve Minio Client conflicts

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -385,7 +385,10 @@ ports += "sysutils/consul-alerts"
 ports += "sysutils/ipfs-go"
 ports += "security/vault"
 ports += "www/minio"
-ports += "www/minio-client"
+ports += {
+    "name": "www/minio-client",
+    "options": ["OPTIONS_FILE_UNSET+=MC"]
+}
 ports += "misc/mmv"
 ports += {
     "name": "net-mgmt/netdata",

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -380,7 +380,10 @@ ports += "converters/convmv"
 
 ports += "sysutils/ipfs-go"
 ports += "www/minio"
-#ports += "www/minio-client"
+ports += {
+    "name": "www/minio-client",
+    "options": ["OPTIONS_FILE_UNSET+=MC"]
+}
 ports += "misc/mmv"
 ports += {
     "name": "net-mgmt/netdata",


### PR DESCRIPTION
Minio client conflicts with 'mc'/midnight commander. This commit fixes that issue and instead of using mc namespace, it uses 'minio-client' instead.
Ticket: #62370