### PR TITLE
Resolve Minio Client conflicts

### DIFF
--- a/build/profiles/fn_head/ports-system.pyd
+++ b/build/profiles/fn_head/ports-system.pyd
@@ -384,7 +384,10 @@ ports += "sysutils/consul-alerts"
 ports += "sysutils/ipfs-go"
 ports += "security/vault"
 ports += "www/minio"
-ports += "www/minio-client"
+ports += {
+    "name": "www/minio-client",
+    "options": ["OPTIONS_FILE_UNSET+=MC"]
+}
 ports += "misc/mmv"
 ports += "net-mgmt/netdata"
 ports += "misc/mbuffer"

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -383,7 +383,10 @@ ports += "sysutils/py-consul"
 ports += "sysutils/consul-alerts"
 ports += "sysutils/ipfs-go"
 ports += "www/minio"
-ports += "www/minio-client"
+ports += {
+    "name": "www/minio-client",
+    "options": ["OPTIONS_FILE_UNSET+=MC"]
+}
 ports += "misc/mmv"
 ports += "net-mgmt/netdata"
 ports += "misc/mbuffer"


### PR DESCRIPTION
Minio client conflicts with 'mc'/midnight commander. This commit fixes that issue and instead of using mc namespace, it uses 'minio-client' instead.