### PR TITLE
NAS-100936: Add ioat(4) as module, new NVDIMM driver will need it.

### DIFF
--- a/build/profiles/fn_head/config.pyd
+++ b/build/profiles/fn_head/config.pyd
@@ -73,6 +73,7 @@ kernel_modules = [
     "nmdm",
     "ntb",
     "nvdimm",
+    "ioat",
     "toecore",
     "cxgb",
     "cxgbe",

--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -73,6 +73,7 @@ kernel_modules = [
     "nmdm",
     "ntb",
     "nvdimm",
+    "ioat",
     "toecore",
     "cxgb",
     "cxgbe",


### PR DESCRIPTION
Ticket:	#76395
Ticket:	#NAS-100936
Ticket:	#NAS-101559
(cherry picked from commit 5e7f44982e883f1c841726b7485218941f4a8bd2)