### PR TITLE
Donot add cherrypy as a default

### DIFF
--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -363,6 +363,10 @@ ports += {
     "name": "www/minio-client",
     "options": ["OPTIONS_FILE_UNSET+=MC"]
 }
+ports += {
+    "name": "www/py-ws4py",
+    "options": ["OPTIONS_FILE_UNSET+=CHERRYPY"]
+}
 ports += "misc/mmv"
 ports += {
     "name": "net-mgmt/netdata",


### PR DESCRIPTION
This commit introduces changes so we don't add cherrypy support for ws4py port as we don't use it and updating ws4py to the latest version conflicts with cherrypy's version as it has not been updated in a few years. We don't use cherrypy, so we can just not build ws4py with it.