### PR TITLE
Unset gevent for ws4py

### DIFF
--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -365,7 +365,7 @@ ports += {
 }
 ports += {
     "name": "www/py-ws4py",
-    "options": ["OPTIONS_FILE_UNSET+=CHERRYPY"]
+    "options": ["OPTIONS_FILE_UNSET+=CHERRYPY", "OPTIONS_FILE_UNSET+=GEVENT"]
 }
 ports += "misc/mmv"
 ports += {


### PR DESCRIPTION
In this commit we unset gevent for ws4py as that is not used by us and not needed in the build.