### PR TITLE
NAS-104015 / 11.3 / Replace ZeroTier with WireGuard in FreeNAS, since ZeroTier is no longer

### DIFF
--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -67,7 +67,7 @@ ports += {
 ports += "misc/cpuid"
 ports += "net-mgmt/clog"
 ports += "net/mosh"
-ports += "net/zerotier"
+ports += "net/wireguard"
 ports += "net-mgmt/sipcalc"
 
 if LABEL != "TrueNAS":


### PR DESCRIPTION
OpenSource.

Ticket: NAS-104015