### PR TITLE
NAS-105355 / None / Add nscd to base install

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -115,7 +115,6 @@ make_conf_build = {
     "WITHOUT_LPR":                  "yes",
     "WITHOUT_NDIS":                 "yes",
     "WITHOUT_NLS":                  "yes",
-    "WITHOUT_NS_CACHING":           "yes",
     "WITHOUT_OBJC":                 "yes",
     "WITH_OPENSSH_NONE_CIPHER":     "yes",
     "WITHOUT_PC_SYSINSTALL":        "yes",

--- a/build/tools/create-iso.py
+++ b/build/tools/create-iso.py
@@ -77,6 +77,7 @@ files_to_preserve = [
     '/usr/bin/uname',
     '/usr/bin/xargs',
     '/usr/sbin/diskinfo',
+    '/usr/sbin/nscd',
     '/usr/sbin/sshd',
     '/usr/sbin/swapinfo',
     '/usr/sbin/vidcontrol',


### PR DESCRIPTION
First step in enable caching for nsswitch subsystem. This is
to improve performance and usability in AD and LDAP environments.