### PR TITLE
NAS-105526 / None / Add mac_ntpd module to build

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -56,6 +56,7 @@ kernel_modules = [
     "linux",
     "linux64",
     "linux_common",
+    "mac_ntpd",
     "msdosfs_iconv",
     "ispfw/ispfw",
     "opensolaris",


### PR DESCRIPTION
mac_ntpd lets the NTP daemon run as a non-root user. The ntpd rc script tries
to load it, but we are missing the module so we see

kldload: can't load mac_ntpd: No such file or directory

on the console and ntpd is run as root instead of the ntpd user.

We have the MAC framework in our kernel config already, all we're missing is
the mac_ntpd module in the build profile config.

Ticket: NAS-105526