### PR TITLE
NAS-105768 / 12.0 / Enable ANSI sequences on serial console

### DIFF
--- a/build/config/templates/cdrom/loader.conf
+++ b/build/config/templates/cdrom/loader.conf
@@ -3,6 +3,7 @@
 #
 product="TrueNAS Installer"
 autoboot_delay="10"
+loader_color="YES"
 loader_logo="TrueNAS"
 loader_menu_title="TrueNAS Installer"
 loader_version=" "


### PR DESCRIPTION
This lets loader emit escape sequences to reset terminal settings,
which may have been left in an unusable state by earlier boot firmware.

Xref: https://github.com/freenas/freenas/pull/4577