### PR TITLE
NAS-105645 / 20.10 / Remove zfs-stats-lite

### DIFF
--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -345,7 +345,6 @@ ports += {
 ports += "misc/mmv"
 ports += "misc/mbuffer"
 ports += "devel/git-lite"
-ports += "sysutils/zfs-stats-lite"
 ports += "sysutils/ncdu"
 
 # There ports are all vm related.


### PR DESCRIPTION
This has been broken for years. arc_summary from OpenZFS should be a
suitable alternative.

Ticket: NAS-105645