### PR TITLE
Add PYTHON option for OpenZFS

### DIFF
--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -24,7 +24,10 @@
 #
 
 ports += "ports-mgmt/pkg"
-ports += "sysutils/openzfs"
+ports += {
+    "name": "sysutils/openzfs",
+    "options": ["OPTIONS_FILE_SET+=PYTHON"]
+}
 ports += "dns/bind-tools"
 ports += "dns/dnsmasq"
 ports += "textproc/jq"


### PR DESCRIPTION
Needed for arcstat, arc_summary, and dbufstat utilities to be installed.