### PR TITLE
NAS-108108 / 12.0 / add new "install" key to build system (by yocalebo)

### DIFF
--- a/build/config/env.pyd
+++ b/build/config/env.pyd
@@ -47,6 +47,11 @@ PRODUCTION = PRODUCTION or "no"
 SDK = SDK or "no"
 BUILD_SDK = BUILD_SDK or "no"
 
+# if a port was given the `install` key and it was set
+# to False, then we don't install that port but we save
+# the associated built *.txz to this directory
+NON_INSTALLED_DIR = "non_installed_ports"
+
 # Any env variable that is profile specific should go in the file(s)
 # below and not in this common env.pyd file.
 # Also note that do not refer to any profile specific variable before

--- a/build/lib/utils.py
+++ b/build/lib/utils.py
@@ -276,6 +276,12 @@ def error(fmt, *args):
 def get_port_names(ports):
     for i in ports:
         if isinstance(i, dict):
+            # since this function is called at the installation
+            # phase of the build process, we check to make sure
+            # that if `install` key is there and if it's set to
+            # false then we don't install it
+            if not i.get('install', True):
+                continue
             if 'package' in i:
                 yield i.package
             else:

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -114,6 +114,10 @@ ports += {
 }
 ports += "lang/python3"
 ports += "lang/python"
+ports += {
+    "name": "lang/python38-debugging",
+    "install": False,
+}
 ports += "sysutils/scanlnk"
 ports += "sysutils/iocage"
 ports += "security/pam_mkhomedir"


### PR DESCRIPTION
Add the ability to specify an `install` key. It's mostly only relevant if you set it to `False`. The associated port will be not included in the install. This is primarily for building a custom port with extravagant compile time settings without including it in the base install image.

Example is to build a custom python port called python38-debugging that includes debug symbols and compile time optimizations turned off.

Original PR: https://github.com/freenas/build/pull/268